### PR TITLE
Make irc an optional dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,10 @@ jobs:
           - name: default
           - name: none
             flags: --no-default-features
+          - name: git
+            flags: --no-default-features -F git
+          - name: irc
+            flags: --no-default-features -F irc
     steps:
     - uses: actions/checkout@v4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,9 +2610,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58800dee30ca82a1c107c64a0effca7ccb4e6106645c0e3af40d5aaba9f5457"
+checksum = "a85348106ab244d90fe2d70faad939b71c5dad1258e5da9116e176064fc6c078"
 dependencies = [
  "jiff-tzdb-platform",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["fuzz"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 [features]
-default = ["git"]
+default = ["git", "irc"]
 git = ["gix", "gix-object"]
 
 [dependencies]
@@ -39,7 +39,7 @@ gix-object = { version = "0.47", optional = true }
 hex = "0.4.3"
 indexmap = "2"
 ipnetwork = "0.21"
-irc = { version = "1", default-features = false, features = ["tls-rust"] }
+irc = { version = "1", optional = true, default-features = false, features = ["tls-rust"] }
 log = "0.4.17"
 lru = "0.12"
 lz4_flex = "0.11.3"

--- a/src/p2p/irc.rs
+++ b/src/p2p/irc.rs
@@ -1,81 +1,23 @@
 use crate::errors::*;
 use crate::p2p;
+use crate::p2p::proto::PeerGossip;
 use futures::prelude::*;
 use irc::client::prelude::{Client, Command, Config, Response};
 use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::time;
+
+pub const IRC_DEBOUNCE: Duration = Duration::from_millis(250);
+pub const IRC_RECONNECT_COOLDOWN: Duration = Duration::from_secs(60); // 1min
+pub const IRC_RECONNECT_JITTER: Duration = Duration::from_secs(60 * 3); // 3min
 
 fn random_nickname() -> String {
     let mut buf = [0u8; 3];
     getrandom::fill(&mut buf).expect("Failed to use getrandom");
     let name = format!("apt-swarm-{}", hex::encode(buf));
     name
-}
-
-#[derive(Debug, PartialEq)]
-pub struct PeerGossip {
-    pub fp: sequoia_openpgp::Fingerprint,
-    pub idx: String,
-    pub count: u64,
-    pub addrs: Vec<SocketAddr>,
-}
-
-impl FromStr for PeerGossip {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        let s = s
-            .strip_prefix("[sync] ")
-            .context("Message is missing the [sync] tag")?;
-
-        let mut split = s.split(' ');
-        let fp = split
-            .next()
-            .context("Missing mandatory attribute: fingerprint")?;
-        let fp = fp
-            .strip_prefix("fp=")
-            .with_context(|| anyhow!("First attribute is expected to be fingerprint: {fp:?}"))?;
-        let fp = fp
-            .parse()
-            .with_context(|| anyhow!("Failed to parse as fingerprint: {fp:?}"))?;
-
-        let idx = split.next().context("Missing mandatory attribute: index")?;
-        let idx = idx
-            .strip_prefix("idx=")
-            .with_context(|| anyhow!("First attribute is expected to be index: {idx:?}"))?
-            .to_string();
-
-        let count = split.next().context("Missing mandatory attribute: count")?;
-        let count = count
-            .strip_prefix("count=")
-            .with_context(|| anyhow!("First attribute is expected to be count: {count:?}"))?;
-        let count = count
-            .parse()
-            .with_context(|| anyhow!("Failed to parse as count: {count:?}"))?;
-
-        let mut addrs = Vec::new();
-
-        for extra in split {
-            if let Some(addr) = extra.strip_prefix("addr=") {
-                let addr = addr
-                    .parse()
-                    .with_context(|| anyhow!("Failed to parse as address: {addr:?}"))?;
-                addrs.push(addr);
-            }
-        }
-
-        Ok(PeerGossip {
-            fp,
-            idx,
-            count,
-            addrs,
-        })
-    }
 }
 
 pub async fn connect_irc(
@@ -166,49 +108,7 @@ pub async fn spawn_irc(
         let Err(err) = connect_irc(&mut rx, &peering_tx).await;
         error!("irc connection has crashed: {err:#}");
 
-        time::sleep(p2p::IRC_RECONNECT_COOLDOWN).await;
-        p2p::random_jitter(p2p::IRC_RECONNECT_JITTER).await;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_irc_no_addrs() -> Result<()> {
-        let s = "[sync] fp=ED541312A33F1128F10B1C6C54404762BBB6E853 idx=sha256:1994bea786a499ec72ce94a45e2830ce31746a5ef4fb7a2b73ba0934e4a046ac count=180";
-        let gi = s.parse::<PeerGossip>()?;
-        assert_eq!(
-            gi,
-            PeerGossip {
-                fp: "ED541312A33F1128F10B1C6C54404762BBB6E853".parse()?,
-                idx: "sha256:1994bea786a499ec72ce94a45e2830ce31746a5ef4fb7a2b73ba0934e4a046ac"
-                    .to_string(),
-                count: 180,
-                addrs: Vec::new(),
-            }
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_parse_irc_multiple_addrs() -> Result<()> {
-        let s = "[sync] fp=2265EB4CB2BF88D900AE8D1B74A941BA219EC810 idx=sha256:55a00753512036f55ccc421217e008e4922c66592e6281b09de2fcba4dbd59ce count=12 addr=192.0.2.146:16169 addr=[2001:db8:c010:8f3a::1]:16169";
-        let gi = s.parse::<PeerGossip>()?;
-        assert_eq!(
-            gi,
-            PeerGossip {
-                fp: "2265EB4CB2BF88D900AE8D1B74A941BA219EC810".parse()?,
-                idx: "sha256:55a00753512036f55ccc421217e008e4922c66592e6281b09de2fcba4dbd59ce"
-                    .to_string(),
-                count: 12,
-                addrs: vec![
-                    "192.0.2.146:16169".parse()?,
-                    "[2001:db8:c010:8f3a::1]:16169".parse()?,
-                ],
-            }
-        );
-        Ok(())
+        time::sleep(IRC_RECONNECT_COOLDOWN).await;
+        p2p::random_jitter(IRC_RECONNECT_JITTER).await;
     }
 }

--- a/src/p2p/peering.rs
+++ b/src/p2p/peering.rs
@@ -136,7 +136,7 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
     db: &mut D,
     keyring: Keyring,
     proxy: Option<SocketAddr>,
-    mut rx: mpsc::Receiver<p2p::irc::PeerGossip>,
+    mut rx: mpsc::Receiver<p2p::proto::PeerGossip>,
 ) -> Result<Infallible> {
     // keep track of connection attempts to avoid flooding
     let mut cooldown = Cooldowns::new();

--- a/src/p2p/proto.rs
+++ b/src/p2p/proto.rs
@@ -1,0 +1,106 @@
+use crate::errors::*;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq)]
+pub struct PeerGossip {
+    pub fp: sequoia_openpgp::Fingerprint,
+    pub idx: String,
+    pub count: u64,
+    pub addrs: Vec<SocketAddr>,
+}
+
+impl FromStr for PeerGossip {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let s = s
+            .strip_prefix("[sync] ")
+            .context("Message is missing the [sync] tag")?;
+
+        let mut split = s.split(' ');
+        let fp = split
+            .next()
+            .context("Missing mandatory attribute: fingerprint")?;
+        let fp = fp
+            .strip_prefix("fp=")
+            .with_context(|| anyhow!("First attribute is expected to be fingerprint: {fp:?}"))?;
+        let fp = fp
+            .parse()
+            .with_context(|| anyhow!("Failed to parse as fingerprint: {fp:?}"))?;
+
+        let idx = split.next().context("Missing mandatory attribute: index")?;
+        let idx = idx
+            .strip_prefix("idx=")
+            .with_context(|| anyhow!("First attribute is expected to be index: {idx:?}"))?
+            .to_string();
+
+        let count = split.next().context("Missing mandatory attribute: count")?;
+        let count = count
+            .strip_prefix("count=")
+            .with_context(|| anyhow!("First attribute is expected to be count: {count:?}"))?;
+        let count = count
+            .parse()
+            .with_context(|| anyhow!("Failed to parse as count: {count:?}"))?;
+
+        let mut addrs = Vec::new();
+
+        for extra in split {
+            if let Some(addr) = extra.strip_prefix("addr=") {
+                let addr = addr
+                    .parse()
+                    .with_context(|| anyhow!("Failed to parse as address: {addr:?}"))?;
+                addrs.push(addr);
+            }
+        }
+
+        Ok(PeerGossip {
+            fp,
+            idx,
+            count,
+            addrs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_irc_no_addrs() -> Result<()> {
+        let s = "[sync] fp=ED541312A33F1128F10B1C6C54404762BBB6E853 idx=sha256:1994bea786a499ec72ce94a45e2830ce31746a5ef4fb7a2b73ba0934e4a046ac count=180";
+        let gi = s.parse::<PeerGossip>()?;
+        assert_eq!(
+            gi,
+            PeerGossip {
+                fp: "ED541312A33F1128F10B1C6C54404762BBB6E853".parse()?,
+                idx: "sha256:1994bea786a499ec72ce94a45e2830ce31746a5ef4fb7a2b73ba0934e4a046ac"
+                    .to_string(),
+                count: 180,
+                addrs: Vec::new(),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_irc_multiple_addrs() -> Result<()> {
+        let s = "[sync] fp=2265EB4CB2BF88D900AE8D1B74A941BA219EC810 idx=sha256:55a00753512036f55ccc421217e008e4922c66592e6281b09de2fcba4dbd59ce count=12 addr=192.0.2.146:16169 addr=[2001:db8:c010:8f3a::1]:16169";
+        let gi = s.parse::<PeerGossip>()?;
+        assert_eq!(
+            gi,
+            PeerGossip {
+                fp: "2265EB4CB2BF88D900AE8D1B74A941BA219EC810".parse()?,
+                idx: "sha256:55a00753512036f55ccc421217e008e4922c66592e6281b09de2fcba4dbd59ce"
+                    .to_string(),
+                count: 12,
+                addrs: vec![
+                    "192.0.2.146:16169".parse()?,
+                    "[2001:db8:c010:8f3a::1]:16169".parse()?,
+                ],
+            }
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
This allows avoiding ring 0.16, which doesn't build on certain architectures.

Related to https://github.com/aatxe/irc/pull/263