### PR TITLE
Add repro-env files (Reproducible Builds)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,44 @@ jobs:
     - name: Build
       run: cargo build --release --verbose
 
+  repro-env:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-linux-musl
+          - x86_64-unknown-linux-musl
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up cargo cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: repro-env-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: repro-env-${{ matrix.target }}-
+
+    - name: Install dependencies (apt)
+      run: sudo apt-get install repro-env
+
+    - name: Build
+      run: make
+
+    - name: Print sha256 of binary
+      run: sha256sum target/${{ matrix.target }}/release/apt-swarm
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: bin-${{ matrix.target }}
+        path: target/${{ matrix.target }}/release/apt-swarm
+
   unit-test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build: aarch64-unknown-linux-musl x86_64-unknown-linux-musl
+
+%-unknown-linux-musl:
+	repro-env build -- sh -c ' \
+	RUSTFLAGS="-C strip=symbols" \
+	cargo build --target $@ --release'
+
+.PHONY: build *-unknown-linux-musl

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,0 +1,274 @@
+[container]
+image = "docker.io/library/archlinux@sha256:2a006ed10836e49964826d6b310b169983bffd474917e02727342012f1b970c2"
+
+[[package]]
+name = "aarch64-linux-gnu-binutils"
+version = "2.43-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/a/aarch64-linux-gnu-binutils/aarch64-linux-gnu-binutils-2.43-1-x86_64.pkg.tar.zst"
+sha256 = "cd9065d56c56570322c9d0b63411d86ba95a1f23932100ca2107840363622f8a"
+signature = "iQIzBAABCAAdFiEEjhmSFnRl21+wRVV8sChU7XU+Dx8FAmc5MB0ACgkQsChU7XU+Dx+VfBAAlw+yFzHoBqm6xIHwF1Q4iR6M2x1kgQstlfaHnP7nL6EwunhmHGQIDf/4Zc2tNqE5q5v8lmHv+YSBO8L4MybyxN/sFG2rv78fAlyJx/UFER92DbMJvHZtZoF2cvX+pvaczw6/rIX77x9PhnzKQASIKXWKsu4Uy9jbZuZLd/XCILFl9kPwFqzNDxNL7pRiakYUsSM8xcXZFUg8wOO5DogGhB0lo2v9mbDmNIkMWLuPB9RqxSk3MkXaU9aETx12bxCbrdmHQHlBlDvEpfDw7wKGUOQTmqXB2h0OUYbOQ7xieyJA1CJ8/K7UL8XEKcmjNa8jaLClPaaOOGju5btEB8VH/GQqsUJXI4rGyFDMJOlcX2+AdBJwSAVO2j2LWafg4Mu+tyfjYzOALvhhEHewyZmYZih2YpcSOdTfdXakeN/gMsg3zNyM/PJn0K1k6CP006ILSSVJHKDIi+CkI7eEv+tbgAj2h0RJxue+YoEqa5M64nJTbPyBV/F9X2L2E4sOLr36z8wGRh2tc2nxWsdntHu3+XE4Jks1imYq6GJUTDUpOgbwnDmUY0eiyQSd8CSvAWdRS32mPBgwOSYbmxCZBK8+MioXEvvg0PWH30o7B0x8MSlb4ZW9EkCvmxhUfWfOzsBW82lVKnwbfg1JBfeZpWBzetI7hqpmGippwPfwleqSet4="
+
+[[package]]
+name = "aarch64-linux-gnu-gcc"
+version = "14.2.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/a/aarch64-linux-gnu-gcc/aarch64-linux-gnu-gcc-14.2.0-1-x86_64.pkg.tar.zst"
+sha256 = "9f68a3a00ec1a4d78d416a0f20487de0bf3d57a35f3a537062b4a0d072c19c19"
+signature = "iQIzBAABCAAdFiEEjhmSFnRl21+wRVV8sChU7XU+Dx8FAmc86w4ACgkQsChU7XU+Dx8uQA//cuxU1P/sWJyhMU+DdBvDJmbdcDWpdCeMce00XIHuQcJSQv5NP9u/rTj/VuVZfBlok8djbp6r1LM47UEYemVPo/0EIEjEV9mYBmywi23+toF++2Wos+qi6UstuDf4hBMSjnxPpcSWWf3SB/gjpMz/IbVwTfk4KeTYy8L/PlohlFlScd6uqADmdfZFKIA0qKOqHMMiKKP1PA+hIcsy3giV3axiK/TQnppRwogigrCHVk92zrGK2achxvWpVvD47ij4V8BrIdvClBfAmMRWDGVqXVhGKr5+EgnCZ/jWdOSQckryvTDe1rKvmiy+CQ/UonAKR/uvUsnZ2r5an1L+Xn7aNLBSPXHrv8qRpmmxSsWYaTiCR5VY7ckaAU8u78IpjNcxmnOcZVdhqnUDuxRWNVvsg6GWvMnowoa8/xlxotz+HxDFiS7mvnf9QITTygzXjXPsVM9ufkP181SSPUEwTrn/V6MCl7NAWuWkTWvZ/h+WdCvil0ymZgulDAU5oeXxYcg1UO2OF2bmEUoi5uOomv+7Rz523wgwOZ3XzQiJN/dEQ4q911vIcDWu9xtW1f5Lvy4lDp1kt37IJaFmXnCX8LLOod6VrGquP+nkMQTY4TA0YhUW/XfoWqWAQ215WUiwXkKbPo48gBFouaZrlgfqI6/kRY+a/uLMqUlWPb1iavgUO3o="
+
+[[package]]
+name = "aarch64-linux-gnu-glibc"
+version = "2.40-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/a/aarch64-linux-gnu-glibc/aarch64-linux-gnu-glibc-2.40-1-any.pkg.tar.zst"
+sha256 = "0e410d29c37ed5af0a4ce0e90103cac5cd78c114d238d7770543b0b35e3c313a"
+signature = "iQIzBAABCAAdFiEEjhmSFnRl21+wRVV8sChU7XU+Dx8FAmc9CIYACgkQsChU7XU+Dx9XYA/+NqMAx/f/orVvkyx2hG1H4Aygi2LVjIG3ca8hAirA3beppWTOGeMSbLRPiOvfH0wGWAbOipqng/312khj36N3EHI8X80IqwyOkxpO24aEuEOFQMH+FgVgSfSiCF5uF1hjspvm0WDc8/mSDsej1vryGacIqh6x0JqzdlXcp80D/jpKvewa3JGheHWei3CAgktKw6jONVBsGiLlkhTm3XrOiv+NNSh81bw3ofGme74j4uQEi2T0TJgw4+LyJ203v30/dxGYtT7A5hYd4+L5vxXtju4Hz7YH+xtQiiRMhR2pcfTS/gdk29c93Uetfb5PHJKhxleG+hOXqwrOfmWPCOZ55mgXDzLHgsI/ZL/gVtasyKorNnYNDZcuC3uIV56e+3GQpn0oeFI8wqT6gEgMi2wbFXsUQqeTlTCSx95CCkR8LFvoIDLQexP6Tu9iC+UYCetF59BVCZLUEVCUP0N6ZpMmk21hesCKAaPk7foNNuXdmOzduZZ2JPcsdNy76DJIR26nbk95jxgxEPEawDhum9nTE+1c/16trcFidNzTTMmwhWRa81qZPQYgZ97TeK8QJrjT+6vXu/+HNfjl5SQ2CFxHWoS/wTFmY3gWyerTM+C48l/4iNg7pHF1chNJXEvzPaDypLtFDt78ItN/5Q0g4usQIJnoNZqV0Sn3SmKNW2BeEvY="
+
+[[package]]
+name = "aarch64-linux-gnu-linux-api-headers"
+version = "6.12-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/a/aarch64-linux-gnu-linux-api-headers/aarch64-linux-gnu-linux-api-headers-6.12-1-any.pkg.tar.zst"
+sha256 = "500d6df001985aefeb2305d5061ebde6b5cc7f67d764827f99d2e9de19498450"
+signature = "iQIzBAABCAAdFiEEjhmSFnRl21+wRVV8sChU7XU+Dx8FAmc74MYACgkQsChU7XU+Dx8dPBAAimRTvl2Kgm+AV5rnmsb2rceOskQ9L4dfcB4iJA/dKGtHB4jnzlGfYez3v4T4JjlwVsbfWcFN47CdbYChHP5wPOgNYNo76B3Qy6eMjpzu7+I/wkI6f8G/oKqYfksaJWp94z1Br5K/Mf09HQCgkLNHtNFCUo/ZEePRKYw9Rcb3hOUZZ02pEcNMy1VtGP25+2beWTr+K9MYgW/rxCTjoRlEVgggAbYU7MECTBZlnauP1VsOqwuBl1EaPXzlcBJX+KODnM088TRMIuLIP4mOVDje2cxhtTyhkMirLn+YYhOhPtqm2r0VgEQgApDYsd3zOujN26lVvefn/Y1i1EUTaK1Ej//K1KGUYEUtouIgXInI0a2PfjSOXn+21c9vTydBZaP9A1qHaw8SA/P8lr+vTkxhW03KPzZ6yMHohzdTRL34lrVjAV/H+yYpDHcAFuLEnHAOs6rnpCwSEGd9yfbieO66lmxNMUdYw/RaLZNtkjIGd2DNOZ2qky5LyxuNx6ibu3MSx9kyFQJFQAqtTSgK2bttbbHVfangSEcV4WK4GHUZ/Ljjb+8qf/Sma2OSbpGBCZQ50Jh5W9ogQ7Rb0lsUhD3OU9NNxOjs2EM2NhXd+3o/7kYjoU2JUrpkDQzCkvgrpPzCg5EPa3shrVuM6zXKT7W8/ZLvONVvhi5ntPTHyMzfo4w="
+
+[[package]]
+name = "binutils"
+version = "2.44-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.44-1-x86_64.pkg.tar.zst"
+sha256 = "8c14a56397669fefff067ec2c08aeccb944372be4f4cdb6fed0991ca18c4fb02"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOK18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjeoAP9btSaBFNMd2M64KII1QXneh2x9+xVvLiz3YZ1kbNMknwEA4+KjPA7GZGgq1HWZsjLuTUWzu4M2D6WBXXfH9HLbiQ0="
+
+[[package]]
+name = "curl"
+version = "8.12.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.12.1-1-x86_64.pkg.tar.zst"
+sha256 = "1dcb4abfc54162c3e1f1d979a45b2ecba1103adfd3f84a0fea6dfc9aaf009d5c"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ62gSwAKCRBtQr3RFuAGj5KSAQCmG2LJfjENljSU5/OB8dh+YTkJD+SS4VKmn9trLQOA8QEAp0Unt81UHIWUE+TkYN5nf6itEF04VEvS5I6CuirN+QE="
+
+[[package]]
+name = "gc"
+version = "8.2.8-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.8-2-x86_64.pkg.tar.zst"
+sha256 = "c7b5e6816e7977a407e3f862b4ac51e7cf70e522c7fe1a72c2eca49431679712"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZt6oQl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCp63AP4zSG9Ph/ey/7pYMn/RNiK9x1gv3SknQQ5dttHxVgc++QD/aXAHmlJ3i2x5kaqtv+bVKMTa80sF/S7X6DKJfQ+Q9Q4="
+
+[[package]]
+name = "gcc"
+version = "14.2.1+r753+g1cd744a6828f-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-14.2.1+r753+g1cd744a6828f-1-x86_64.pkg.tar.zst"
+sha256 = "2f5d57f8047bd95dc8ca89878e276968e485fec552a1d6222cbe7d4b020e5b8f"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOMl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCs1BAQDhgm29sxvOmglFqaPf7w14Smqpbd/q83FwqUZX5fyqPwD+Obh+eLgaLHPq2DwHGH8TPoFEHlbMhU82pk2DkvU6qQE="
+
+[[package]]
+name = "gcc-libs"
+version = "14.2.1+r753+g1cd744a6828f-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-14.2.1+r753+g1cd744a6828f-1-x86_64.pkg.tar.zst"
+sha256 = "3353d8c2ca5bdc1295e05966fe756a4f4d83e42b4026111bbae73d4b00191917"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOM18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCrmJAP9vlvtgJs2yxvTpEWl1toaOVUO+/GtzuofAW8yguzAPpwEAhMSqYXcF/fo87zqyf9KNfR4/RXYq+mei7dpbqRRFKww="
+
+[[package]]
+name = "glibc"
+version = "2.41+r6+gcf88351b685d-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.41+r6+gcf88351b685d-1-x86_64.pkg.tar.zst"
+sha256 = "f93b58f22814522bf66df0f4af9c2a17d1cf7013318381bb62faf8d780f840fa"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOJ18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCsGWAP9C+bm6JwqEoNj3rPAPriqjW6VeL2rEH7AkiGWBe0Nq6wEAu0xPTN9J4/40cXhZMVM8r9x9mqe9McvVCxacGYPbDwg="
+
+[[package]]
+name = "gnutls"
+version = "3.8.9-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gnutls/gnutls-3.8.9-1-x86_64.pkg.tar.zst"
+sha256 = "3af3356d36926c984e80403d4712fd2319ccc9122012da7ede00d06ebe0e9c7b"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmenlHAACgkQlGV6sg8qCSsS3AgAtwqfbaB3e05lGoupcvSp5JUzyaG+K1DakqdB8BMEJFvifnwti3OtFWalaRkkOPu+eQiGPNo5JWbm7j1QB7y7A5T85LUFeXYnVhPqMF70dfhSvTOgbtOgbX2gXIh6A6zPri+7RgvmfWMXuXQq+wVzcXBlwjLPFeM7yo9G6/K0azt/E7mNj/rbPH/P+mkEELNKMPHF3ZwCAgTp+sZSJh7Fr6QbRjn4BBxxjuamVqnLFYYr45RskmW+xbRmi7XoRzUzAomZrtVWmMWd0iScRX2Yr/vlmnE5Od8smIcO5z80yJVTj3cfji2Cgs+MWccpitZUYYQylCYcWBDe8KgXO2/nxw=="
+
+[[package]]
+name = "gpgme"
+version = "1.24.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.24.2-1-x86_64.pkg.tar.zst"
+sha256 = "351e43bb4f5e336f4c1f5f146a385b9c2e08f09e1c16e35933190808fd59fbf3"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ6snqQAKCRBtQr3RFuAGj4K3AQDdkpVdVkj3Twc8rKamuVKf3EOoDXBC0qasLKCDeOA1rQEA6g6LpU2WyDRmyG6/c76BzaOJSJfHfoIcpxkkdXragwM="
+
+[[package]]
+name = "guile"
+version = "3.0.10-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
+sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
+
+[[package]]
+name = "jansson"
+version = "2.14-4"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/j/jansson/jansson-2.14-4-x86_64.pkg.tar.zst"
+sha256 = "a67ab57d4a9b4caa2e718652c392345cdd9c2496d835ab1d0ff1e78ae4429fde"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjJful8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpfCAP4sFnTjSEIn5wDbLWGZOivsWT2SWPG6AgofrnUjaK/UMAD9E2u6D7WJbVTYrvDhVUz3WN6k8bVB8ZODyoIF66GWEw0="
+
+[[package]]
+name = "leancrypto"
+version = "1.2.0-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/leancrypto/leancrypto-1.2.0-2-x86_64.pkg.tar.zst"
+sha256 = "f558b37e8db38130a789afdecf89546ac91fdf098bbeacfffa2b8d63d582237a"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmeoqMgACgkQlGV6sg8qCStclAf7BkZAG0SclIrGEC+V0ll2zy1gdHnaAEtYQRB4HV/EDoLmiZ79ogdSfzUQbokM29hMVY5j3eRe6fn+wh5CpUxfEzMtpNtgQdf/8oAuywk3t/qRPx/p5B/SoAvq+UC8bNX8bGouwr6K41uXRewpRLn9Wp637NzqzEcuJ7vMFMGIRA7Hre10xDMKqZQq8b9l5xUrAOy4ezLLw6O8MwFjwXPZf2hMwh2rAPe/31yen4Fka/gkpgInBh09U+o09PWtrdM422SSp3md01WqCWtfK4h3BhZQK+TCKZVWL3JhJZYo890HvnKtATFpd9O/PW8687RcHMuPfU89+YFG9/4lTa1OSQ=="
+
+[[package]]
+name = "libedit"
+version = "20240808_3.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libedit/libedit-20240808_3.1-1-x86_64.pkg.tar.zst"
+sha256 = "f7888a3a880f16f172f71fd83b081988798ae8f57faa4abe3e8a7a30f00fc461"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmd1ZSYACgkQdx32Yn7faB8s+Qf+M5JqNn+fOWer/158BMRSB9PCCR2u047R4Iu4Os4eOne5q4Lw/Z6ox6KTgXHaOEEN0E6K/a6atOy7TrRS1sbx4+I0CGAsBQ7R2+oqyZpIiWE+jNydTsQsiN5jljFAHigoXhsnP5x96Ef9sTEcTsjE2cAtThmGj5v8h67kmGC/rEAffIDhfuZK9Yp/GJ2DkY/yzxKyrechYGQEmR28i7O6oiZGaURd8Ra0xe6jUjN35gXM13KeOyz9OR8VPvaZ7eP/RYEcvqjv2ZxeP6oRTzSz+EkqykbGFdVob0iRJ9pt7K0UUcz2rczcHPO2Cz5MiI2h85fQ6MQvsPfCAs0exTwPmQ=="
+
+[[package]]
+name = "libelf"
+version = "0.192-4"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.192-4-x86_64.pkg.tar.zst"
+sha256 = "a085de7bca9fb174ada0ca368b89ae55fa285b9e497942200db3c1709e269515"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dg018UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaClm0AQCdxj4mxHarqd4bnLK1Ymo8mxxKenQOS4zzTwhWHHcBVQD/elQzdF4kdce6XdHfAmubDHXEWO9F5cWQ1rwIfOJjvgQ="
+
+[[package]]
+name = "libisl"
+version = "0.27-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libisl/libisl-0.27-1-x86_64.pkg.tar.zst"
+sha256 = "55a36e8195e6d9ce2efeb4276c60df6b6e7d94812fa36f8423d5ce664a5d34df"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZtWJeV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCgPbAP9GNpnE0ra4qZOGYyJtfnyG42f8Z9dLpX21F/sY/a2UCgD/dz8x7harwjTofWctVHyyCacJsLhSq2jvSfrvvL4H/w8="
+
+[[package]]
+name = "libmpc"
+version = "1.3.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
+sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
+
+[[package]]
+name = "libsysprof-capture"
+version = "47.2-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libsysprof-capture/libsysprof-capture-47.2-3-x86_64.pkg.tar.zst"
+sha256 = "18277cf029509770b03316d2e70e8d9c44915733003c2d8cd29aee7f2c46ae00"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dgr18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCoJDAQCp3NiX7SJ3U1hc+8kJYfavn7kIm6XX4cun55cVgGNFiQEAqhkmnR+usihlZ+08m/zvmZB6MEt1QLCpJjsYWcByjwg="
+
+[[package]]
+name = "linux-api-headers"
+version = "6.13-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/linux-api-headers/linux-api-headers-6.13-1-x86_64.pkg.tar.zst"
+sha256 = "58741d10a943ea769e3043a45e1af94e589771c712fb3da4612627bd7b8db156"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ5oqcV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCrddAQCoXbmYWnn5iEPm+pAoiVm5ElL8VMrQWlvOAVYm6jzXGAEA8zrqdFmKPHvEi6OpnKR8NrywvMLhvsuXXcsQTl/6BQk="
+
+[[package]]
+name = "llvm-libs"
+version = "19.1.7-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-19.1.7-1-x86_64.pkg.tar.zst"
+sha256 = "44de8dac4c85c2297d8a8b9b4f8a71d422bd2452b6b0f442859f92c5319daad3"
+signature = "iQEzBAABCAAdFiEEhs/8qRjPOvRxR1iAUeixSKmZnDQFAmeLq+kACgkQUeixSKmZnDSQcgf/UE3HidSGyn485QxUdNk6ffxyRMIxQixiaMPVcFQlTCNoC2c3oN/Y9bp5qWN2Oydh5J17nVy6el5mpVzaSFrVA05cFP0eoOIy1RrlC2ko54icSmchRyD1bGHfwBNlurkCU5y1AQqbo+5Exfg31Vj5NsXdDst5E51WfP37/NxZ9holoXk17Lb5vcgQ/GTgmzEWL7Gt+CF5X0AkPCOejBtBrzcSWM2T4s6dGatM45PCTSWHzgLbi9RuZwd2y0jPZPPocvsmxoi1q0KhjteCXWJpn/HpksmiiRNIG1RN9uV7Vp9f0rVEoWaf1VbdzNyXrdoRFxdxg1Nt0en9VrwhMuX4Mg=="
+
+[[package]]
+name = "make"
+version = "4.4.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
+sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
+signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
+
+[[package]]
+name = "mpfr"
+version = "4.2.1-6"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/mpfr/mpfr-4.2.1-6-x86_64.pkg.tar.zst"
+sha256 = "ed8b562fbea4490a35463e11713c4c2b11e4600577c6bb7c1acdc540a8b1a906"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dg2F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCj/2AQDkDd+y0oD4esOTn/2QCH2pqNSDhOU2tPWbD1rdMT06pgD+IUQAEmDNfc7XpbKv6wxORVk1iBu3PXYFJq32ZCkHGwM="
+
+[[package]]
+name = "musl"
+version = "1.2.5-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-3-x86_64.pkg.tar.zst"
+sha256 = "d06d3154f4b9feebb5e2089870f4aece3d943199e7a2c9cae8adc1fa4ffce049"
+signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmeRK5AACgkQRaZQ4mOMU234pg//X5HK6EANyDMYQepeAXGeD/tZmQ5RWyi4OKe61vdc9EZLjUAon3kWsJDvcfyIJWBdONuyjb4IQmRPPu/ZtGsy0844K3SIKNnJk8bsGtMWUVXO/oV/qrdrE3i6111rgXBeTG4+KVTwOzXkl/CnGZGre03QmFvtR4p/TJufBxLtc5WxKJ+CXMwvb0cQhuacPY2NiHuSgQxa9q8fbr+F6MDZeOhLTygrNlZcgwTHPq4oka6/2Ulo6KOFWfc6bwOpvG/pXc0i3Rve8cIK0loROagK5mqQvOJ3IaO3Qx3SZsY/JhauzxroX0YszqDgNYf1fWvB+deUR7A7S6yRUMfvR4VXtXkgapMAnmNZRMyVIYfmTHGu2X7F5Rt8uD4ryhx8uzU8wsFEVrSGsTYLuJaSJifNdDvLd65cFTItmsXsJcbR8POAE9agZH/4pgxFXyICa6uZfesy3gdD7gndoGHZbKhcR+Aufp+MKPYkjg1zaJtIQGn2/9ck4y1JEJO34IO+qF7GzqI+hWyhemmJnbMxIASafcNgSyrCnEaR3ep0LJl9NyNTOKPxk66YGbRPQ7qggEv7SGotZHcTCJ+4mNIlsM5ONBB9APpHnx0irwCuM8SdXKb6PaY0L4THeNcPTA1PYQEfFuzpBChz41qmg7HPaTq+CjP+iyit4qOIC5dsisLdSaE="
+
+[[package]]
+name = "musl-aarch64"
+version = "1.2.5-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/m/musl-aarch64/musl-aarch64-1.2.5-3-x86_64.pkg.tar.zst"
+sha256 = "dd3c34fce98e897b0d231974477baf61732adb5bca7ba0c5671e2c7e5e23b7bf"
+signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmeRK5AACgkQRaZQ4mOMU22xPg/+MKTFrbAk5iKKgFcsC/7NnQza/hMZagBw0NNfDcJPch6iSOoqQIQlbHpu5zHWbWfRYz3OuE7afUsENd9igRiu4P8hx6hRRsxqJXsTEO+9GDJsGE223ll/gU56aLiMe+wDkAqNZ4GeoZ6KGQAiO7zv6mncr/UgzGkDRxLAdIjy+jW2tXhX9x/YB+eCu1dKgRrjyb2je92qhC8q1/znKEDzeh8rSuD8UVdltDsqVPKE9/lHVu6cfYmWtPAzHTBVpTRc0PvskC9VuAQvnBD456+IkTzFz8VdcEyyAUm4m59kKCg+kkt9KApgYjbPDLngyxlGA99PG/8v3bqqwnLVMrfrZNu5SPq8J4GDDtaUgzJ20/7u3RcndG1hKF6yhoB9sUZ0MlHw2ATnzBSEObV2Fcn/ZgpnJl8GUBTWYHCoWysPS0wNRQUKCixDZhIjJzA40etvqvpxKvYAAn9uJ4F1DrQ2lG2g5WaMQ7wBMQlPyDSSf6p/QRjq+l04NW2krq7FhM5RybEuuaYh1o0zN+w5QRCa6FDp3lE3zWeUP1mosuv0ScbghCBlRa7QKX+HlCUgMRijRq2yIpd6vQV58y3YfHbeZFaTFjymHSo/kPDzvt12gv5s3zkhsN99e8itPCU4WjmBQr4ZP9wQPBtRF88xkuKOcOnZoPvJ1TO2oPe+hZZE8zE="
+
+[[package]]
+name = "openssl"
+version = "3.4.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.4.1-1-x86_64.pkg.tar.zst"
+sha256 = "124c9e7f5c37ce39c7f2af9516d7ff8b6ad3c37b32f70f9e8ffbf427f15b8bdd"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ6uTXQAKCRBtQr3RFuAGj74SAQDU+cNGTzN0jmwSwbGsWGcvmlq8wIra32Ct96asqUqvUwD/chKA74bV0zyxkXOH+VO9n7K78CTzZZTsHeM3Tj6QhQA="
+
+[[package]]
+name = "pam"
+version = "1.7.0-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/pam/pam-1.7.0-2-x86_64.pkg.tar.zst"
+sha256 = "ebd2e8ba4b4904efd0d40eb9c3f6a61c681a520acbfb68209a325326964c9519"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmel6hMACgkQdx32Yn7faB+P6Qf/RSiJsTFsDBA/RDVmZwyDStOY3lBXDY8HPBQmhou6GJ2IW058rbfnh9IHJwPWHcYLrkWMFBtoiqRPyUMNgctu2kjLHOMsxhLtRYlYgigc1Ys2x25H7BaGFalvaeU5E18fPMCgTXOPTaBxtp/7mlQDfyf9HHOKGkinVCxOYAT9p7zF82UiIyVToujrk3szSP6V8JfTyb5ZbQKLEhRJXZSbhMXCgt5rFshUkN+QclNZeSwOO6UVyLRO/HzJ2isH3EMfwrwPu2USQaMm7ThtcQCeb11vidQDP+4k8HpSWQDuE8vp2U09v3autFbXnmhwvs2qiItR1rp517nOe+4GEO1Kdg=="
+
+[[package]]
+name = "rust"
+version = "1:1.84.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.84.1-1-x86_64.pkg.tar.zst"
+sha256 = "f020f738045e13855c19cdc61976ca16cc3c1031a7afea74e61019a947443f5b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ5yFIwAKCRC4rAhgDxCM3ysdAP0YX/Qw9kF/l+7W+xxvnjmsyk6i7kVxieQZYW8KaTsITAEA+sW4KXH19WgZoNsR07qvRYbzXP979SIdXbR642dAqwA="
+
+[[package]]
+name = "rust-aarch64-musl"
+version = "1:1.84.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust-aarch64-musl/rust-aarch64-musl-1:1.84.1-1-x86_64.pkg.tar.zst"
+sha256 = "0642ce7d9d27e7148cba3ad33b890986c417bb2586df935f01de6611a92a2590"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ5yFKQAKCRC4rAhgDxCM388iAP0XpLJnb7rzapbYnFEQQfsNKOoK93so9V4KJD+j8WLJHgD/f99NIFWXCXS/zRJsPNFyoGjBN+BvbtPayIAe8Z457wI="
+
+[[package]]
+name = "rust-musl"
+version = "1:1.84.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.84.1-1-x86_64.pkg.tar.zst"
+sha256 = "0744973d99b76c638cb3c1f75bbc83837129d2591366059240c240e7694a6d48"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ5yFJgAKCRC4rAhgDxCM31byAQCUCqyKfohPVuTQgLZpMzKpEalwFXJWKzwJK33iEnn9wgEAiblE9Y52pF41Mb1YesO+ySwFwaqgKOhTmeQ97JSf4As="
+
+[[package]]
+name = "systemd"
+version = "257.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-257.3-1-x86_64.pkg.tar.zst"
+sha256 = "cc8c1cab34ef4b1878974f70c8cdb79b14dfdf969b5277a87e923932c2ad82d4"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ65FggAKCRBtQr3RFuAGj7kTAP957bqPL6GVEjuKrD7yDc3zSEj+A2HzUS7XW+Tpz7IkGQD/YXEbon+IAErzUx3w0uXBxklOgzh9FdqkpvwYG/XeAws="
+
+[[package]]
+name = "systemd-libs"
+version = "257.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-257.3-1-x86_64.pkg.tar.zst"
+sha256 = "03ee3d79a1952e425df61eac19e454f6d4bea138b24a7a11af82c58045b56145"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ65FgwAKCRBtQr3RFuAGj1aSAQCkRfdTIW1wQ+l0aJWnLOGArDGUp0IJll9DEZT8shihiwD/ekvoGrrvTmexxcs0bREuEwhL0J+Z/MuE9tHVapRs3wo="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "257.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-257.3-1-x86_64.pkg.tar.zst"
+sha256 = "93eb47f37db5dc56f0e66a3a9c03b28edd81db1d59b79c9850668607f6a204f4"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ65FgwAKCRBtQr3RFuAGj2nCAP98tsyy8rBGWaMvEXzD15wuFdlnxo7bn2D4WpNmK2vj1wEA0EQd8SqVcQQ/D99XUooPH+i30TBcstDaJ6vJ3z1SWwg="

--- a/repro-env.toml
+++ b/repro-env.toml
@@ -1,0 +1,12 @@
+[container]
+image = "docker.io/library/archlinux"
+
+[packages]
+system = "archlinux"
+dependencies = [
+    "make",
+    "musl",
+    "musl-aarch64",
+    "rust-aarch64-musl",
+    "rust-musl",
+]


### PR DESCRIPTION
This allows building a canonical binary, given a commit, for reproducible builds without needing additional buildinfo files.