### PR TITLE
Implement PEX server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "apt-swarm"
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.44"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+checksum = "1e3040c8291884ddf39445dc033c70abc2bc44a42f0a3a00571a0f483a83f0cd"
 dependencies = [
  "clap",
 ]
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -2524,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array 0.14.7",
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "lru"
@@ -2841,9 +2841,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -3202,7 +3202,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustc-hash",
  "rustls 0.23.23",
  "rustls-pki-types",
@@ -3268,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags",
 ]
@@ -3399,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.9"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
 dependencies = [
  "cc",
  "cfg-if",
@@ -3481,7 +3481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -3493,7 +3493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -3543,7 +3543,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.10",
  "untrusted 0.9.0",
 ]
 
@@ -3553,7 +3553,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.10",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -3591,7 +3591,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.9",
+ "ring 0.17.10",
  "untrusted 0.9.0",
 ]
 
@@ -3675,18 +3675,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3695,9 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -3812,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4129,7 +4129,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.2",
+ "winnow 0.7.3",
 ]
 
 [[package]]
@@ -4205,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uluru"
@@ -4226,9 +4226,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/src/args.rs
+++ b/src/args.rs
@@ -396,4 +396,8 @@ pub struct SyncPull {
 
 /// Provide access to our signatures over stdio (use with sync-pull)
 #[derive(Debug, Parser)]
-pub struct SyncYield {}
+pub struct SyncYield {
+    /// Enable access to peer-exchange queries
+    #[arg(long)]
+    pub pex: bool,
+}

--- a/src/p2p/peering.rs
+++ b/src/p2p/peering.rs
@@ -198,7 +198,7 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
             }
             _ = interval.tick() => {
                 // Automatically pick a known peer
-                let addrs = peerdb.sample().await?;
+                let addrs = peerdb.sample(Duration::MAX).await?;
                 debug!("Automatically selected peers for periodic sync: {addrs:?}");
                 SyncRequest {
                     hint: None,

--- a/src/p2p/peering.rs
+++ b/src/p2p/peering.rs
@@ -3,11 +3,10 @@ use crate::errors::*;
 use crate::keyring::Keyring;
 use crate::net;
 use crate::p2p;
-use crate::p2p::peerdb::PeerDb;
+use crate::p2p::peerdb::{self, MetricType};
 use crate::p2p::proto::{PeerAddr, SyncRequest};
 use crate::sync;
 use crate::timers::EasedInterval;
-use chrono::Utc;
 use ipnetwork::IpNetwork;
 use sequoia_openpgp::Fingerprint;
 use std::collections::VecDeque;
@@ -53,21 +52,19 @@ pub const COOLDOWN_HOST_THRESHOLD: usize = 10;
 pub async fn pull_from_peer<D: DatabaseClient + Sync + Send>(
     db: &mut D,
     keyring: &Keyring,
-    peerdb: &mut PeerDb,
+    peerdb: &peerdb::Client,
     fingerprints: &[Fingerprint],
     addr: &PeerAddr,
     proxy: Option<SocketAddr>,
 ) -> Result<()> {
-    let (peer, _new) = peerdb.add_peer(addr.clone());
-
     // setup connection
     let mut sock = match net::connect(addr, proxy).await {
         Ok(sock) => {
-            peer.connect.successful();
+            peerdb.successful(MetricType::Connect, addr.clone());
             sock
         }
         Err(err) => {
-            peer.connect.error();
+            peerdb.error(MetricType::Connect, addr.clone());
             return Err(err);
         }
     };
@@ -76,15 +73,15 @@ pub async fn pull_from_peer<D: DatabaseClient + Sync + Send>(
     // perform handshake
     match net::handshake(&mut rx, &mut tx).await {
         Ok(_) => {
-            peer.handshake.successful();
+            peerdb.successful(MetricType::Handshake, addr.clone());
         }
         Err(err) => {
-            peer.handshake.error();
+            peerdb.error(MetricType::Handshake, addr.clone());
             tx.shutdown().await.ok();
             return Err(err);
         }
     }
-    peerdb.write().await?;
+    peerdb.write();
 
     // sync from peer
     let result = sync::sync_pull(db, keyring, fingerprints, false, &mut tx, rx).await;
@@ -180,7 +177,7 @@ impl Default for Cooldowns {
 pub async fn spawn<D: DatabaseClient + Sync + Send>(
     db: &mut D,
     keyring: Keyring,
-    mut peerdb: PeerDb,
+    peerdb: peerdb::Client,
     proxy: Option<SocketAddr>,
     mut rx: mpsc::Receiver<p2p::proto::SyncRequest>,
 ) -> Result<Infallible> {
@@ -195,14 +192,13 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
                 let Some(req) = req else { break };
 
                 // register all addresses as known before attempting to sync
-                peerdb.add_advertised_peers(&req.addrs);
-                peerdb.write().await?;
+                peerdb.add_advertised_peers(req.addrs.clone());
 
                 req
             }
             _ = interval.tick() => {
                 // Automatically pick a known peer
-                let addrs = peerdb.sample();
+                let addrs = peerdb.sample().await?;
                 debug!("Automatically selected peers for periodic sync: {addrs:?}");
                 SyncRequest {
                     hint: None,
@@ -258,7 +254,7 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
             p2p::random_jitter(P2P_SYNC_CONNECT_JITTER).await;
 
             info!("Syncing from remote peer: {addr:?}");
-            let ret = pull_from_peer(db, &keyring, &mut peerdb, &[], &addr, proxy).await;
+            let ret = pull_from_peer(db, &keyring, &peerdb, &[], &addr, proxy).await;
             debug!("Connection to {addr:?} has been closed");
             match ret {
                 Ok(_) => {
@@ -270,11 +266,7 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
                     cooldown.mark_bad(addr);
                 }
             }
-            peerdb.write().await?;
-        }
-
-        if peerdb.expire_old_peers(Utc::now()) {
-            peerdb.write().await?;
+            peerdb.write();
         }
     }
 

--- a/src/p2p/peering.rs
+++ b/src/p2p/peering.rs
@@ -198,7 +198,7 @@ pub async fn spawn<D: DatabaseClient + Sync + Send>(
             }
             _ = interval.tick() => {
                 // Automatically pick a known peer
-                let addrs = peerdb.sample(Duration::MAX).await?;
+                let addrs = peerdb.sample(None).await?;
                 debug!("Automatically selected peers for periodic sync: {addrs:?}");
                 SyncRequest {
                     hint: None,

--- a/src/p2p/sync.rs
+++ b/src/p2p/sync.rs
@@ -1,20 +1,26 @@
 use crate::db::DatabaseServerClient;
 use crate::errors::*;
-use crate::p2p;
+use crate::p2p::{self, peerdb};
 use crate::sync;
 use std::convert::Infallible;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 
-pub async fn serve_sync_client(db: &mut DatabaseServerClient, mut stream: TcpStream) -> Result<()> {
+pub async fn serve_sync_client(
+    db: &mut DatabaseServerClient,
+    peerdb: peerdb::Client,
+    mut stream: TcpStream,
+) -> Result<()> {
     let (rx, mut tx) = stream.split();
-    let result = sync::sync_yield(db, rx, &mut tx, Some(p2p::SYNC_IDLE_TIMEOUT)).await;
+    let result =
+        sync::sync_yield(db, Some(peerdb), rx, &mut tx, Some(p2p::SYNC_IDLE_TIMEOUT)).await;
     tx.shutdown().await.ok();
     result
 }
 
 pub async fn spawn_sync_server(
     db: &DatabaseServerClient,
+    peerdb: peerdb::Client,
     listener: TcpListener,
 ) -> Result<Infallible> {
     loop {
@@ -22,8 +28,9 @@ pub async fn spawn_sync_server(
         debug!("Accepted connection from client: {:?}", src_addr);
 
         let mut db = db.clone();
+        let peerdb = peerdb.clone();
         tokio::spawn(async move {
-            if let Err(err) = serve_sync_client(&mut db, stream).await {
+            if let Err(err) = serve_sync_client(&mut db, peerdb, stream).await {
                 error!("Error while serving client: {err:#}");
             } else {
                 debug!("Client disconnected: {src_addr:?}");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -294,16 +294,14 @@ pub async fn sync_yield<
                 }
             }
             Query::Pex => {
+                let mut buf = String::new();
                 if let Some(peerdb) = &peerdb {
-                    let mut buf = String::new();
                     for addr in peerdb.sample(PEX_MAX_SUCCESS_AGE).await? {
                         buf += &format!("{addr}\n");
                     }
-                    tx.write_all(format!(":{}\n", buf.len()).as_bytes()).await?;
-                    tx.write_all(buf.as_bytes()).await?;
-                } else {
-                    tx.write_all(b":0\n").await?;
                 }
+                tx.write_all(format!(":{}\n", buf.len()).as_bytes()).await?;
+                tx.write_all(buf.as_bytes()).await?;
             }
             Query::Unknown(data) => {
                 debug!("Received unknown command from network: {data:?}");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -316,15 +316,12 @@ impl SyncQueue {
 
     pub fn pop_next(&mut self) -> Option<Option<String>> {
         loop {
-            if let Some(mut entry) = self.queues.last_entry() {
-                let queue = entry.get_mut();
-                if let Some(item) = queue.pop_front() {
-                    return Some(item);
-                } else {
-                    entry.remove_entry();
-                }
+            let mut entry = self.queues.last_entry()?;
+            let queue = entry.get_mut();
+            if let Some(item) = queue.pop_front() {
+                return Some(item);
             } else {
-                return None;
+                entry.remove_entry();
             }
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -296,7 +296,7 @@ pub async fn sync_yield<
             Query::Pex => {
                 let mut buf = String::new();
                 if let Some(peerdb) = &peerdb {
-                    for addr in peerdb.sample(PEX_MAX_SUCCESS_AGE).await? {
+                    for addr in peerdb.sample(Some(PEX_MAX_SUCCESS_AGE)).await? {
                         buf += &format!("{addr}\n");
                     }
                 }


### PR DESCRIPTION
Allow querying other peer's peerdb for known addresses over the network.

This moves `PeerDb` into it's own worker thread so both `sync_yield` (incoming connections) and `peering` (outgoing connections) have read/write access to it.

TODO:
- [x] Don't advertise peers we haven't recently successfully handshaked with
  - This needs some parameter for `.sample()` to tell apart if this is for a connection attempt or for peer sharing