### PR TITLE
Add system.announce= to config file

### DIFF
--- a/contrib/apt-swarm.conf
+++ b/contrib/apt-swarm.conf
@@ -1,3 +1,13 @@
+[system]
+## The advertised port for incoming connections.
+## With this setting disabled, we are likely not going to receive incoming
+## connections, but somebody may still connect to our IP manually.
+## Future versions may try to auto-detect the correct values.
+#announce = ["[2001:db8::1]:1337", "192.168.0.1:16169"]
+
+## The list of repositories to monitor.
+## Each entry is one or multiple public keys, and a set of urls to check for
+## signed data.
 [[repository]]
 urls = [
     "https://deb.debian.org/debian/dists/bookworm/InRelease",

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -108,13 +108,17 @@ pub async fn spawn(
         let mut db_client = db_client.clone();
         let keyring = keyring.clone();
         let repositories = config.data.repositories;
+
+        let mut announce = config.data.system.announce;
+        announce.extend(p2p.announce);
+
         set.spawn(async move {
             fetch::spawn_fetch_timer(
                 &mut db_client,
                 keyring,
                 repositories,
                 proxy,
-                p2p.announce,
+                announce,
                 irc_tx,
             )
             .await


### PR DESCRIPTION
This moves custom command-line flag to the config file so I can use standard init-service files.